### PR TITLE
Allow const and unit enum variants in test_case

### DIFF
--- a/ntest/tests/integration.rs
+++ b/ntest/tests/integration.rs
@@ -7,7 +7,7 @@ use std::{thread, time};
 #[should_panic]
 #[test_case(10)]
 #[timeout(100)]
-fn test_function(i: u32) {
+fn test_function(i: u64) {
     let sleep_time = time::Duration::from_millis(i);
     thread::sleep(sleep_time);
 }

--- a/ntest/tests/integration.rs
+++ b/ntest/tests/integration.rs
@@ -2,13 +2,33 @@ use ntest::test_case;
 use ntest::timeout;
 use std::{thread, time};
 
+const TWO_HUNDRED: u64 = 200;
+const TEN: u64 = 10;
+
 #[test_case(200)]
 #[timeout(100)]
 #[should_panic]
 #[test_case(10)]
 #[timeout(100)]
+#[test_case(TWO_HUNDRED)]
+#[timeout(100)]
+#[should_panic]
+#[test_case(TEN)]
+#[timeout(100)]
 fn test_function(i: u64) {
     let sleep_time = time::Duration::from_millis(i);
+    thread::sleep(sleep_time);
+}
+
+#[repr(u8)]
+enum Test { A = 200, B = 10 }
+#[test_case(Test::A)]
+#[timeout(100)]
+#[should_panic]
+#[test_case(Test::B)]
+#[timeout(100)]
+fn test_with_enum(i: Test) {
+    let sleep_time = time::Duration::from_millis(i as u8 as _);
     thread::sleep(sleep_time);
 }
 


### PR DESCRIPTION
This MR does two things:

1. It allows const and unit enum variants in test_case, allowing code such as

    ```rust
    enum Test { A, B }
    #[test_case(Test::A)]
    fn test_with_enum(i: Test) {
        match i {
            Test::A => println!("A"),
            Test::B => println!("B"),
        }
    }
    ```

2. It properly sets the type of the arguments in the assignment. Previously, `test_case` would assign the arguments by doing `let a = 1`. This meant that the type was left to be figured out by the type inference mechanism, and meant that the type in the function signature could be wrong. This was actually the case in ntest's own integration tests! `test_function` took a `u32` argument, but passed it to a function expecting an `u64`. This worked because the types weren't checked.

     We now properly check the types by generating assignments of the form `let a: u64 = 1;`. This is technically a breaking change, but I believe it only breaks code that is "wrong".