### PR TITLE
Timeout: Use fully qualified path to  to avoid potnetial conflicts.

### DIFF
--- a/ntest_timeout/src/lib.rs
+++ b/ntest_timeout/src/lib.rs
@@ -64,10 +64,10 @@ pub fn timeout(attr: TokenStream, item: TokenStream) -> TokenStream {
             
             let (sender, receiver) = std::sync::mpsc::channel();
             std::thread::spawn(move || {
-                if let Ok(()) = sender.send(ntest_callback()) {}
+                if let std::result::Result::Ok(()) = sender.send(ntest_callback()) {}
             });
             match receiver.recv_timeout(std::time::Duration::from_millis(#time_ms)) {
-                Ok(t) => return t,
+                std::result::Result::Ok(t) => return t,
                 Err(std::sync::mpsc::RecvTimeoutError::Timeout) => panic!("timeout: the function call took {} ms. Max time {} ms", ntest_timeout_now.elapsed().as_millis(), #time_ms),
                 Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => panic!(),
             }
@@ -80,7 +80,7 @@ fn check_other_attributes(input: &syn::ItemFn) {
     for attribute in &input.attrs {
         let meta = attribute.parse_meta();
         match meta {
-            Ok(m) => match m {
+            std::result::Result::Ok(m) => match m {
                 syn::Meta::Path(p) => {
                     let identifier = p.get_ident().expect("Expected identifier!");
                     if identifier == "timeout" {


### PR DESCRIPTION
This PR changes all occurrences of `Ok(...)` to `std::result::Result::Ok(...)`.

Rust's procedural macros are not hygenic so symbols in the macro code can conflict with symbols in the user code. In my case, I had another enum with a variant named `Ok` in scope, so the macro generated code tried to use my custom one instead.

By using the fully qualified path, there is no ambiguity.