### PR TITLE
fix: rust analyzer snake case test cases arguments

### DIFF
--- a/ntest_test_cases/src/lib.rs
+++ b/ntest_test_cases/src/lib.rs
@@ -121,7 +121,7 @@ pub fn test_case(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let mut result = proc_macro2::TokenStream::new();
     for test_description in test_descriptions {
-        let test_case_name = syn::Ident::new(&test_description.name.to_lowercase(), Span::call_site());
+        let test_case_name = syn::Ident::new(&test_description.name, Span::call_site());
         let literals = test_description.args;
         let attributes = test_description.attributes;
         if literals.len() != fn_args_idents.len() {
@@ -130,6 +130,7 @@ pub fn test_case(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         let test_case_quote = quote! {
             #[test]
+            #[allow(non_snake_case)]
             #(#attributes)*
             fn #test_case_name() #fn_return {
                 #(let #fn_args_idents: #fn_args_ty = #literals;)*

--- a/ntest_test_cases/src/lib.rs
+++ b/ntest_test_cases/src/lib.rs
@@ -121,7 +121,7 @@ pub fn test_case(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let mut result = proc_macro2::TokenStream::new();
     for test_description in test_descriptions {
-        let test_case_name = syn::Ident::new(&test_description.name, Span::call_site());
+        let test_case_name = syn::Ident::new(&test_description.name.to_lowercase(), Span::call_site());
         let literals = test_description.args;
         let attributes = test_description.attributes;
         if literals.len() != fn_args_idents.len() {


### PR DESCRIPTION
Issue: https://github.com/becheran/ntest/issues/21
Make generated `test_case` test description lower case to avoid `rust-analyzer incorrect-ident-case` warning