### PR TITLE
Iterate over all elements of `Path` when making sure `timeout` is not used twice

### DIFF
--- a/ntest_timeout/src/lib.rs
+++ b/ntest_timeout/src/lib.rs
@@ -83,20 +83,17 @@ fn check_other_attributes(input: &syn::ItemFn) {
         match meta {
             std::result::Result::Ok(m) => match m {
                 syn::Meta::Path(p) => {
-                    let identifier = p.get_ident().expect("Expected identifier!");
-                    if identifier == "timeout" {
+                    if p.segments.iter().any(|ps| ps.ident == "timeout") {
                         panic!("Timeout attribute is only allowed once");
                     }
                 }
                 syn::Meta::List(ml) => {
-                    let identifier = ml.path.get_ident().expect("Expected identifier!");
-                    if identifier == "timeout" {
+                    if ml.path.segments.iter().any(|ps| ps.ident == "timeout") {
                         panic!("Timeout attribute is only allowed once");
                     }
                 }
                 syn::Meta::NameValue(nv) => {
-                    let identifier = nv.path.get_ident().expect("Expected identifier!");
-                    if identifier == "timeout" {
+                    if nv.path.segments.iter().any(|ps| ps.ident == "timeout") {
                         panic!("Timeout attribute is only allowed once");
                     }
                 }


### PR DESCRIPTION
This fixes code completion inside intellij-rust and rust-analyzer when using another proc macro with tests, like `#[tokio::test]`.
Before this change Intellij (CLion in my case), Fleet and Helix all would have broken completion in tests using both `#[tokio::test]` and `#[ntest::timeout(1000]`. Additionally Fleet marks whole test function as build error and Helix with debug logs enabled logs the panics.

Debug log from Helix with expect modified to `expect(&format!("Expected identifier! {p:?}"))`:
<details>
<summary>Details</summary>

```
2023-07-18T16:40:35.183 helix_lsp::transport [ERROR] err <- "thread '<unnamed>' panicked at 'Expected identifier! Path { leading_colon: Some(Colon2), segments: [PathSegment { ident: Ident { ident: \"core\", span: 4 }, arguments: None }, Colon2, PathSegment { ident: Ident { ident: \"prelude\", span: 7 }, arguments: None }, Colon2, PathSegment { ident: Ident { ident: \"v1\", span: 10 }, arguments: None }, Colon2, PathSegment { ident: Ident { ident: \"test\", span: 13 }, arguments: None }] }', /home/mateusz/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ntest_timeout-0.9.0/src/lib.rs:87:26\n"
2023-07-18T16:40:35.183 helix_lsp::transport [ERROR] err <- "stack backtrace:\n"
2023-07-18T16:40:35.183 helix_lsp::transport [ERROR] err <- "   0: rust_begin_unwind\n"
2023-07-18T16:40:35.183 helix_lsp::transport [ERROR] err <- "             at /rustc/8ede3aae28fe6e4d52b38157d7bfe0d3bceef225/library/std/src/panicking.rs:593:5\n"
2023-07-18T16:40:35.183 helix_lsp::transport [ERROR] err <- "   1: core::panicking::panic_fmt\n"
2023-07-18T16:40:35.183 helix_lsp::transport [ERROR] err <- "             at /rustc/8ede3aae28fe6e4d52b38157d7bfe0d3bceef225/library/core/src/panicking.rs:67:14\n"
2023-07-18T16:40:35.183 helix_lsp::transport [ERROR] err <- "   2: core::panicking::panic_display\n"
2023-07-18T16:40:35.183 helix_lsp::transport [ERROR] err <- "             at /rustc/8ede3aae28fe6e4d52b38157d7bfe0d3bceef225/library/core/src/panicking.rs:150:5\n"
2023-07-18T16:40:35.183 helix_lsp::transport [ERROR] err <- "   3: core::panicking::panic_str\n"
2023-07-18T16:40:35.183 helix_lsp::transport [ERROR] err <- "             at /rustc/8ede3aae28fe6e4d52b38157d7bfe0d3bceef225/library/core/src/panicking.rs:134:5\n"
2023-07-18T16:40:35.183 helix_lsp::transport [ERROR] err <- "   4: core::option::expect_failed\n"
2023-07-18T16:40:35.183 helix_lsp::transport [ERROR] err <- "             at /rustc/8ede3aae28fe6e4d52b38157d7bfe0d3bceef225/library/core/src/option.rs:1932:5\n"
2023-07-18T16:40:35.183 helix_lsp::transport [ERROR] err <- "   5: core::option::Option<T>::expect\n"
2023-07-18T16:40:35.183 helix_lsp::transport [ERROR] err <- "   6: ntest_timeout::check_other_attributes\n"
2023-07-18T16:40:35.183 helix_lsp::transport [ERROR] err <- "   7: ntest_timeout::timeout\n"
2023-07-18T16:40:35.184 helix_lsp::transport [ERROR] err <- "   8: core::ops::function::Fn::call\n"
2023-07-18T16:40:35.184 helix_lsp::transport [ERROR] err <- "   9: proc_macro::bridge::client::Client<(proc_macro::TokenStream,proc_macro::TokenStream),proc_macro::TokenStream>::expand2::{{closure}}::{{closure}}\n"
2023-07-18T16:40:35.185 helix_lsp::transport [ERROR] err <- "  10: proc_macro::bridge::client::run_client::{{closure}}::{{closure}}::{{closure}}\n"
2023-07-18T16:40:35.185 helix_lsp::transport [ERROR] err <- "  11: proc_macro::bridge::scoped_cell::ScopedCell<T>::set::{{closure}}\n"
2023-07-18T16:40:35.185 helix_lsp::transport [ERROR] err <- "  12: proc_macro::bridge::scoped_cell::ScopedCell<T>::replace\n"
2023-07-18T16:40:35.185 helix_lsp::transport [ERROR] err <- "  13: proc_macro::bridge::client::run_client::{{closure}}::{{closure}}\n"
2023-07-18T16:40:35.185 helix_lsp::transport [ERROR] err <- "  14: std::thread::local::LocalKey<T>::try_with\n"
2023-07-18T16:40:35.185 helix_lsp::transport [ERROR] err <- "  15: proc_macro::bridge::client::run_client::{{closure}}\n"
2023-07-18T16:40:35.185 helix_lsp::transport [ERROR] err <- "  16: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once\n"
2023-07-18T16:40:35.185 helix_lsp::transport [ERROR] err <- "  17: std::panicking::try::do_call\n"
2023-07-18T16:40:35.185 helix_lsp::transport [ERROR] err <- "  18: __rust_try\n"
2023-07-18T16:40:35.185 helix_lsp::transport [ERROR] err <- "  19: std::panicking::try\n"
2023-07-18T16:40:35.185 helix_lsp::transport [ERROR] err <- "  20: proc_macro::bridge::client::run_client\n"
2023-07-18T16:40:35.185 helix_lsp::transport [ERROR] err <- "  21: proc_macro::bridge::client::Client<(proc_macro::TokenStream,proc_macro::TokenStream),proc_macro::TokenStream>::expand2::{{closure}}\n"
2023-07-18T16:40:35.185 helix_lsp::transport [ERROR] err <- "  22: proc_macro::bridge::selfless_reify::reify_to_extern_c_fn_hrt_bridge::wrapper\n"
2023-07-18T16:40:35.185 helix_lsp::transport [ERROR] err <- "  23: proc_macro::bridge::server::run_server::<proc_macro_srv::abis::abi_sysroot::ra_server::RustAnalyzer, (proc_macro::bridge::Marked<proc_macro_srv::abis::abi_sysroot::ra_server::token_stream::TokenStream, proc_macro::bridge::client::TokenStream>, proc_macro::bridge::Marked<proc_macro_srv::abis::abi_sysroot::ra_server::token_stream::TokenStream, proc_macro::bridge::client::TokenStream>), core::option::Option<proc_macro::bridge::Marked<proc_macro_srv::abis::abi_sysroot::ra_server::token_stream::TokenStream, proc_macro::bridge::client::TokenStream>>, proc_macro::bridge::server::SameThread>\n"
2023-07-18T16:40:35.185 helix_lsp::transport [ERROR] err <- "  24: <proc_macro_srv::dylib::Expander>::expand\n"
2023-07-18T16:40:35.185 helix_lsp::transport [ERROR] err <- "note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.\n"
```

</details>

Related to https://github.com/becheran/ntest/issues/18 but does not fix it (at least in Fleet).