### PR TITLE
deps: Accept proc-macro-crate v2

### DIFF
--- a/ntest_timeout/Cargo.toml
+++ b/ntest_timeout/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 [dependencies]
 quote = "1.0"
 proc-macro2 = "1.0"
-proc-macro-crate = "1.1"
+proc-macro-crate = ">=1.1,<=2"
 
 [dependencies.syn]
 version = "1.0"


### PR DESCRIPTION
This compiles in both version (1.1+, 2.0+) so no change in MSRV :tada:. I ran the tests with 2.0+, all green.
