### PR TITLE
Fix missing fully-qualified path in generated code to std::marker::Sync

### DIFF
--- a/ntest_timeout/src/lib.rs
+++ b/ntest_timeout/src/lib.rs
@@ -65,7 +65,7 @@ pub fn timeout(attr: TokenStream, item: TokenStream) -> TokenStream {
             #body
             let ntest_timeout_now = std::time::Instant::now();
             
-            type NtestPanicPayload = std::boxed::Box<dyn std::any::Any + Send + 'static>;
+            type NtestPanicPayload = std::boxed::Box<dyn std::any::Any + std::marker::Send + 'static>;
             // Channel sends Result: Ok for success, Err for panic payload
             let (sender, receiver) = std::sync::mpsc::channel::<std::result::Result<_, NtestPanicPayload>>();
             std::thread::spawn(move || {


### PR DESCRIPTION
The c00a637 commit has introduced a **breaking change**, by expanding the `#[timeout]` macro to a code which assumes Rust prelude, but breaks if `Send`  is not `std::marker::Send`

Note: this is a simple fix made in the GitHub editor without actually running tests.